### PR TITLE
Handle RegExp match on HTTP call

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-bootstrap": "^1.0.0-beta.8",
     "react-dom": "^16.8.6",
     "swagger-parser": "^6.0.5",
+    "typescript-optional": "^2.0.1",
     "webextension-polyfill": "^0.4.0",
     "webextension-polyfill-ts": "^0.9.0",
     "xstate": "^4.5.0"

--- a/src/ts/parsers/page.test.ts
+++ b/src/ts/parsers/page.test.ts
@@ -5,16 +5,18 @@ describe("Building spec from page content", () => {
   test("parses paths", async () => {
     const petsPageContent: PageContent = {
       title: "Page title",
-      innerHtml: "<html><body>GET /v1/pets PUT /v2/pets</body></html>",
-      textContent: "GET /v1/pets PUT /v2/pets",
+      innerHtml: "<html><body>GET /v1/pets/:id PUT /v2/pets</body></html>",
+      textContent: "GET /v1/pets/:id PUT /v2/pets",
     };
     const spec = await buildSpecFrom(petsPageContent);
     expect(Object.keys(spec.paths)).toHaveLength(2);
-    expect(spec.paths).toHaveProperty("/v1/pets");
-    const pathItem = spec.paths["/v1/pets"];
+    expect(spec.paths).toHaveProperty("/v1/pets/:id");
+    const pathItem = spec.paths["/v1/pets/:id"];
     expect(pathItem).toBeDefined();
     const operationItem = pathItem.get;
     expect(operationItem).toBeDefined();
+    expect(operationItem.parameters).toHaveLength(1);
+    expect(operationItem.parameters[0].name).toBe("id");
   });
   test("parses RTD-style paths", async () => {
     const rtdPageContent: PageContent = {
@@ -30,5 +32,6 @@ describe("Building spec from page content", () => {
     expect(pathItem).toBeDefined();
     const operationItem = pathItem.get;
     expect(operationItem).toBeDefined();
+    expect(operationItem.parameters).toHaveLength(1);
   });
 });

--- a/src/ts/parsers/page.test.ts
+++ b/src/ts/parsers/page.test.ts
@@ -1,17 +1,32 @@
 import { buildSpecFrom } from "./page";
 import { PageContent } from "../common/types";
 
-const pageContent: PageContent = {
-  title: "Page title",
-  innerHtml: "<html></html><body>GET /v1/pets PUT /v2/pets</body>",
-  textContent: "GET /v1/pets PUT /v2/pets",
-};
-
 describe("Building spec from page content", () => {
   test("parses paths", async () => {
-    const spec = await buildSpecFrom(pageContent);
+    const petsPageContent: PageContent = {
+      title: "Page title",
+      innerHtml: "<html><body>GET /v1/pets PUT /v2/pets</body></html>",
+      textContent: "GET /v1/pets PUT /v2/pets",
+    };
+    const spec = await buildSpecFrom(petsPageContent);
     expect(Object.keys(spec.paths)).toHaveLength(2);
+    expect(spec.paths).toHaveProperty("/v1/pets");
     const pathItem = spec.paths["/v1/pets"];
+    expect(pathItem).toBeDefined();
+    const operationItem = pathItem.get;
+    expect(operationItem).toBeDefined();
+  });
+  test("parses RTD-style paths", async () => {
+    const rtdPageContent: PageContent = {
+      title: "Page title",
+      innerHtml:
+        "<html><<body>GET /api/v2/project/(int: id)/ plus some other stuff</body>/html>",
+      textContent: "GET /api/v2/project/(int: id)/ plus some other stuff",
+    };
+    const spec = await buildSpecFrom(rtdPageContent);
+    expect(Object.keys(spec.paths)).toHaveLength(1);
+    expect(spec.paths).toHaveProperty("/api/v2/project/:id/");
+    const pathItem = spec.paths["/api/v2/project/:id/"];
     expect(pathItem).toBeDefined();
     const operationItem = pathItem.get;
     expect(operationItem).toBeDefined();

--- a/src/ts/parsers/page.ts
+++ b/src/ts/parsers/page.ts
@@ -5,7 +5,6 @@ import {
   PathsObject,
   OperationObject,
   PathItemObject,
-  ParameterObject,
 } from "openapi3-ts";
 import { merge as _merge } from "lodash";
 import * as _ from "lodash";
@@ -54,10 +53,6 @@ export const parsePathsObjectFromHttpCallMatch = (
 };
 
 export const parsePathsFromPage = (pageContent: PageContent): PathsObject => {
-  // TODO Revisit the pattern if the greedy quantifiers are a performance hazard
-  /*
-  const pattern = /(GET|POST|DELETE|PUT)\s((?:\/[\w.\/-:{}\(\)]*)+)/g;*/
-
   let paths: PathsObject = {};
   let patternExecResult = httpCallPattern.exec(pageContent.textContent);
 

--- a/src/ts/parsers/page.ts
+++ b/src/ts/parsers/page.ts
@@ -11,7 +11,7 @@ import { merge as _merge } from "lodash";
 import * as _ from "lodash";
 import * as SwaggerParser from "swagger-parser";
 import debug from "../common/logging";
-import { extractPathParametersFull } from "./paths";
+import { cleanPathAndExtractParameters } from "./paths";
 
 const debugLog = debug("unmock:parsers:page");
 
@@ -44,7 +44,7 @@ export const parsePathsObjectFromHttpCallMatch = (
   match: RegExpExecArray
 ): PathsObject => {
   const path = { name: match[2], pathParameters: [] };
-  const cleanedPath = extractPathParametersFull(path);
+  const cleanedPath = cleanPathAndExtractParameters(path);
   const operationName = match[1].toLowerCase();
   const operation = _merge({}, operationBase, {
     parameters: cleanedPath.pathParameters,

--- a/src/ts/parsers/page.ts
+++ b/src/ts/parsers/page.ts
@@ -60,7 +60,6 @@ export const parsePathsFromPage = (pageContent: PageContent): PathsObject => {
 
   let paths: PathsObject = {};
   let patternExecResult = httpCallPattern.exec(pageContent.textContent);
-  console.log(`Matching to`, pageContent.textContent);
 
   while (patternExecResult !== null) {
     const fullMatch: RegExpExecArray = patternExecResult;

--- a/src/ts/parsers/page.ts
+++ b/src/ts/parsers/page.ts
@@ -46,7 +46,10 @@ export const parsePathsObjectFromHttpCallMatch = (
   const path = { name: match[2], pathParameters: [] };
   const cleanedPath = extractPathParametersFull(path);
   const operationName = match[1].toLowerCase();
-  const pathItem: PathItemObject = { [operationName]: operationBase };
+  const operation = _merge({}, operationBase, {
+    parameters: cleanedPath.pathParameters,
+  });
+  const pathItem: PathItemObject = { [operationName]: operation };
   return { [cleanedPath.name]: pathItem };
 };
 

--- a/src/ts/parsers/paths.test.ts
+++ b/src/ts/parsers/paths.test.ts
@@ -1,18 +1,32 @@
-import { Path, extractPathParametersFull } from "./paths";
+import { Path, cleanPathAndExtractParameters } from "./paths";
+import { SchemaObject } from "openapi3-ts";
 
 describe("Parsing paths", () => {
-  test("works for simple path", () => {
+  test("works for path with a parameter", () => {
+    const pathName = "/api/v2/project/:id/";
+    const path: Path = {
+      name: pathName,
+      pathParameters: [],
+    };
+    const processedPath: Path = cleanPathAndExtractParameters(path);
+    expect(processedPath.name).toBe("/api/v2/project/:id/");
+    expect(processedPath.pathParameters).toHaveLength(1);
+    const pathParameter = processedPath.pathParameters[0];
+    expect(pathParameter.name).toBe("id");
+  });
+  test("works for RTD-like path", () => {
     const pathName = "/api/v2/project/(int: id)/";
     const path: Path = {
       name: pathName,
       pathParameters: [],
     };
-    /*
-    const processedPath: Path = PathProcessor.of(path).map(
-      extractPathParameters
-    ).value;
-    */
-    const processedPath: Path = extractPathParametersFull(path);
+    const processedPath: Path = cleanPathAndExtractParameters(path);
     expect(processedPath.name).toBe("/api/v2/project/:id/");
+    expect(processedPath.pathParameters).toHaveLength(1);
+    const pathParameter = processedPath.pathParameters[0];
+    expect(pathParameter.name).toBe("id");
+    const schema = pathParameter.schema as SchemaObject;
+    expect(schema).toBeDefined();
+    expect(schema.type).toBe("integer");
   });
 });

--- a/src/ts/parsers/paths.test.ts
+++ b/src/ts/parsers/paths.test.ts
@@ -1,9 +1,4 @@
-import {
-  Path,
-  PathProcessor,
-  extractPathParameters,
-  extractPathParametersFull2,
-} from "./paths";
+import { Path, extractPathParametersFull } from "./paths";
 
 describe("Parsing paths", () => {
   test("works for simple path", () => {
@@ -17,7 +12,7 @@ describe("Parsing paths", () => {
       extractPathParameters
     ).value;
     */
-    const processedPath: Path = extractPathParametersFull2(path);
-    expect(processedPath.name).toBe("/api/v2/project/(int: id)/");
+    const processedPath: Path = extractPathParametersFull(path);
+    expect(processedPath.name).toBe("/api/v2/project/:id/");
   });
 });

--- a/src/ts/parsers/paths.test.ts
+++ b/src/ts/parsers/paths.test.ts
@@ -1,0 +1,15 @@
+import { Path, PathProcessor, extractPathParameters } from "./paths";
+
+describe("Parsing paths", () => {
+  test("works for simple path", () => {
+    const pathName = "/api/v2/project/(int: id)/";
+    const path: Path = {
+      name: pathName,
+      pathParameters: [],
+    };
+    const processedPath: Path = PathProcessor.of(path).map(
+      extractPathParameters
+    ).value;
+    expect(processedPath.name).toBe("/api/v2/project/(int: id)/");
+  });
+});

--- a/src/ts/parsers/paths.test.ts
+++ b/src/ts/parsers/paths.test.ts
@@ -1,4 +1,9 @@
-import { Path, PathProcessor, extractPathParameters } from "./paths";
+import {
+  Path,
+  PathProcessor,
+  extractPathParameters,
+  extractPathParametersFull2,
+} from "./paths";
 
 describe("Parsing paths", () => {
   test("works for simple path", () => {
@@ -7,9 +12,12 @@ describe("Parsing paths", () => {
       name: pathName,
       pathParameters: [],
     };
+    /*
     const processedPath: Path = PathProcessor.of(path).map(
       extractPathParameters
     ).value;
+    */
+    const processedPath: Path = extractPathParametersFull2(path);
     expect(processedPath.name).toBe("/api/v2/project/(int: id)/");
   });
 });

--- a/src/ts/parsers/paths.ts
+++ b/src/ts/parsers/paths.ts
@@ -6,12 +6,19 @@ export interface Path {
   pathParameters: ParameterObject[];
 }
 
+/**
+ * Transform a single route portion of path and maybe extract an OpenAPI spec compatible ParameterObject.
+ * For example, for `(int: id)`, return `[":id", `parameterObject]`, where `parameterObject`has schema `type: integer`.
+ * As another example, for `:id`, return `[":id", parmaeterObject]` without the type information.
+ * @param str Part of path, for example `:id` or `(int: id)`.
+ */
 const cleanPartOfPathAndExtractParameters = (
   str: string
 ): [string, ParameterObject | undefined] => {
   const rtdPathPattern = /^\(([\w_]+):\s?([\w_]+)\)$/;
   const rtdMatch = str.match(rtdPathPattern);
-  const colonMatch = str.match(/^:([\w_]+)/);
+  const colonPathPattern = /^:([\w_]+)/;
+  const colonMatch = str.match(colonPathPattern);
   if (rtdMatch) {
     const parameterName = rtdMatch[2];
     // TODO Better
@@ -37,7 +44,11 @@ const cleanPartOfPathAndExtractParameters = (
   return [str, null];
 };
 
-export const extractPathParametersRtd = (path: Path): Path => {
+/**
+ * @param path Path object built from, e.g., `/v1/pets/:id`.
+ * @returns Transformed path object with extracted path parameters.
+ */
+export const cleanPathAndExtractParameters = (path: Path): Path => {
   const pathSplit = path.name.split("/");
   const params: ParameterObject[] = [];
   const cleanedPathSplit = pathSplit.map(value => {
@@ -59,7 +70,3 @@ export const extractPathParametersRtd = (path: Path): Path => {
     pathParameters: path.pathParameters.concat(...params),
   };
 };
-
-export const extractPathParametersFull: (path: Path) => Path = _.flow([
-  extractPathParametersRtd,
-]);

--- a/src/ts/parsers/paths.ts
+++ b/src/ts/parsers/paths.ts
@@ -13,26 +13,34 @@ export interface Path {
   pathParameters: ParameterObject[];
 }
 
-export const extractPathParametersSimple = (path: Path): Path => {
+export const extractPathParametersRtd = (path: Path): Path => {
   const pathSplit = path.name.split("/");
-  // const params: ParameterObject[] = [];
+  const params: ParameterObject[] = [];
   const cleanedPathSplit = pathSplit.map(value => {
-    const rtdPathPattern = /^\((\w+):\s(\w+)\)$/;
+    const rtdPathPattern = /^\((\w+):\s?(\w+)\)$/;
     const match = value.match(rtdPathPattern);
     if (match) {
       // const parameterType = match[0];
       const parameterName = match[2];
+      // Urgh, ugly side-effect in map
+      const parameterObject: ParameterObject = {
+        name: parameterName,
+        in: "path",
+        required: true,
+        schema: {}, // TODO
+      };
+      params.push(parameterObject);
       return `:${parameterName}`;
     }
     return value;
   });
-  return { ...path, name: cleanedPathSplit.join("/") };
-};
-
-export const extractPathParametersRtd = (path: Path): Path => {
-  return { ...path, name: "/v2/pets" };
+  return {
+    ...path,
+    name: cleanedPathSplit.join("/"),
+    pathParameters: path.pathParameters.concat(...params),
+  };
 };
 
 export const extractPathParametersFull: (path: Path) => Path = _.flow([
-  extractPathParametersSimple,
+  extractPathParametersRtd,
 ]);

--- a/src/ts/parsers/paths.ts
+++ b/src/ts/parsers/paths.ts
@@ -1,11 +1,4 @@
-import {
-  OpenApiBuilder,
-  OpenAPIObject,
-  PathsObject,
-  OperationObject,
-  PathItemObject,
-  ParameterObject,
-} from "openapi3-ts";
+import { ParameterObject } from "openapi3-ts";
 import * as _ from "lodash";
 
 export interface Path {
@@ -13,26 +6,52 @@ export interface Path {
   pathParameters: ParameterObject[];
 }
 
+const cleanPartOfPathAndExtractParameters = (
+  str: string
+): [string, ParameterObject | undefined] => {
+  const rtdPathPattern = /^\(([\w_]+):\s?([\w_]+)\)$/;
+  const rtdMatch = str.match(rtdPathPattern);
+  const colonMatch = str.match(/^:([\w_]+)/);
+  if (rtdMatch) {
+    const parameterName = rtdMatch[2];
+    // TODO Better
+    const schema = rtdMatch[1] === "int" ? { type: "integer" } : {};
+    const parameterObject: ParameterObject = {
+      name: parameterName,
+      in: "path",
+      required: true,
+      schema,
+    };
+    return [`:${parameterName}`, parameterObject];
+  } else if (colonMatch) {
+    const parameterName = colonMatch[1];
+    const schema = {};
+    const parameterObject: ParameterObject = {
+      name: parameterName,
+      in: "path",
+      required: true,
+      schema,
+    };
+    return [str, parameterObject];
+  }
+  return [str, null];
+};
+
 export const extractPathParametersRtd = (path: Path): Path => {
   const pathSplit = path.name.split("/");
   const params: ParameterObject[] = [];
   const cleanedPathSplit = pathSplit.map(value => {
-    const rtdPathPattern = /^\((\w+):\s?(\w+)\)$/;
-    const match = value.match(rtdPathPattern);
-    if (match) {
-      // const parameterType = match[0];
-      const parameterName = match[2];
-      // Urgh, ugly side-effect in map
-      const parameterObject: ParameterObject = {
-        name: parameterName,
-        in: "path",
-        required: true,
-        schema: {}, // TODO
-      };
-      params.push(parameterObject);
-      return `:${parameterName}`;
+    const [
+      cleanedPath,
+      maybeParameterObject,
+    ] = cleanPartOfPathAndExtractParameters(value);
+
+    // Urgh, ugly side-effect in map
+    if (maybeParameterObject) {
+      params.push(maybeParameterObject);
     }
-    return value;
+
+    return cleanedPath;
   });
   return {
     ...path,

--- a/src/ts/parsers/paths.ts
+++ b/src/ts/parsers/paths.ts
@@ -3,17 +3,29 @@ import * as _ from "lodash";
 import { Optional } from "typescript-optional";
 
 export interface PartOfPath {
+  /**
+   * Part of path, for example `:id`
+   */
   name: string;
+  /**
+   * Path parameter extracted from `name`, would be present and have `name: id` for `:id`.
+   */
   pathParameter?: ParameterObject;
 }
 
 export interface Path {
+  /**
+   * Full path, for example `/v1/pets/:id`
+   */
   name: string;
+  /**
+   * Path parameters extracted from parts of path such as `:id`
+   */
   pathParameters: ParameterObject[];
 }
 
 /**
- * @param str Part of route, for example, `(int :id)`
+ * @param str Part of path, for example, `(int: id)`
  * @returns Filled optional if part of route matches the expected pattern, empty otherwise.
  */
 const tryHandleRouteWithParentheses = (str: string): Optional<PartOfPath> => {
@@ -38,10 +50,10 @@ const tryHandleRouteWithParentheses = (str: string): Optional<PartOfPath> => {
 };
 
 /**
- * @param str Part of route, for example, `:id`
- * @returns Filled optional if part of route matches the expected pattern, empty otherwise.
+ * @param str Part of path, for example, `:id`
+ * @returns Filled optional if part of path matches the expected pattern, empty otherwise.
  */
-const tryHandleRouteWithColon = (str: string): Optional<PartOfPath> => {
+const tryHandleRouteStartingWithColon = (str: string): Optional<PartOfPath> => {
   const colonPathPattern = /^:([\w_]+)/;
   const colonMatch = str.match(colonPathPattern);
   if (!colonMatch) {
@@ -70,7 +82,7 @@ export const cleanPathAndExtractParameters = (path: Path): Path => {
   const pathParameterObjects: ParameterObject[] = [];
   const cleanedPathSplit = pathSplit.map(partOfPath => {
     const cleanedPartOfPath: PartOfPath = Optional.of(partOfPath)
-      .flatMap(tryHandleRouteWithColon)
+      .flatMap(tryHandleRouteStartingWithColon)
       .or(() => tryHandleRouteWithParentheses(partOfPath))
       .orElse({ name: partOfPath });
 

--- a/src/ts/parsers/paths.ts
+++ b/src/ts/parsers/paths.ts
@@ -1,0 +1,60 @@
+import {
+  OpenApiBuilder,
+  OpenAPIObject,
+  PathsObject,
+  OperationObject,
+  PathItemObject,
+  ParameterObject,
+} from "openapi3-ts";
+
+export interface Path {
+  name: string;
+  pathParameters: ParameterObject[];
+}
+
+export class Monad<A> {
+  public static of<B>(a: B): Monad<B> {
+    return new Monad(a);
+  }
+  public static identity<B>(): (monad: Monad<B>) => Monad<B> {
+    return monad => monad;
+  }
+  private value_: A;
+  constructor(value: A) {
+    this.value_ = value;
+  }
+  public map(f: (value: A) => A): Monad<A> {
+    return Monad.of(f(this.value_));
+  }
+  public chain(f: (monad: Monad<A>) => Monad<A>): Monad<A> {
+    return f(this);
+  }
+  public get value(): A {
+    return this.value_;
+  }
+}
+
+export class PathProcessor extends Monad<Path> {
+  public static updatePathName(path: Path, name: string): Path {
+    return {
+      ...path,
+      name,
+    };
+  }
+  public static addPathParameter(
+    path: Path,
+    pathParameter: ParameterObject
+  ): Path {
+    return {
+      pathParameters: path.pathParameters.concat(pathParameter),
+      ...path,
+    };
+  }
+  constructor(path: Path) {
+    super(path);
+  }
+}
+
+export const extractPathParameters = (path: Path): Path => {
+  return PathProcessor.updatePathName(path, "/v1/pets");
+};

--- a/src/ts/parsers/paths.ts
+++ b/src/ts/parsers/paths.ts
@@ -13,59 +13,26 @@ export interface Path {
   pathParameters: ParameterObject[];
 }
 
-export class Monad<A> {
-  public static of<B>(a: B): Monad<B> {
-    return new Monad(a);
-  }
-  public static identity<B>(): (monad: Monad<B>) => Monad<B> {
-    return monad => monad;
-  }
-  private value_: A;
-  constructor(value: A) {
-    this.value_ = value;
-  }
-  public map(f: (value: A) => A): Monad<A> {
-    return Monad.of(f(this.value_));
-  }
-  public flatMap(f: (value: A) => Monad<A>): Monad<A> {
-    return f(this.value);
-  }
-  public get value(): A {
-    return this.value_;
-  }
-}
-
-export class PathProcessor extends Monad<Path> {
-  public static updatePathName(path: Path, name: string): Path {
-    return {
-      ...path,
-      name,
-    };
-  }
-  public static addPathParameter(
-    path: Path,
-    pathParameter: ParameterObject
-  ): Path {
-    return {
-      pathParameters: path.pathParameters.concat(pathParameter),
-      ...path,
-    };
-  }
-  constructor(path: Path) {
-    super(path);
-  }
-}
-
-function compose<X>(...fs: Array<(x: X) => X>): (x: X) => X {
-  return (x: X) => fs.reduceRight((y, f) => f(y), x);
-}
-
-export const extractPathParameters = (path: Path): Path => {
-  return PathProcessor.updatePathName(path, "/v1/pets");
+export const extractPathParametersSimple = (path: Path): Path => {
+  const pathSplit = path.name.split("/");
+  // const params: ParameterObject[] = [];
+  const cleanedPathSplit = pathSplit.map(value => {
+    const rtdPathPattern = /^\((\w+):\s(\w+)\)$/;
+    const match = value.match(rtdPathPattern);
+    if (match) {
+      // const parameterType = match[0];
+      const parameterName = match[2];
+      return `:${parameterName}`;
+    }
+    return value;
+  });
+  return { ...path, name: cleanedPathSplit.join("/") };
 };
 
-export const extractPathParametersFull = compose(extractPathParameters);
+export const extractPathParametersRtd = (path: Path): Path => {
+  return { ...path, name: "/v2/pets" };
+};
 
-export const extractPathParametersFull2: (path: Path) => Path = _.flow([
-  extractPathParameters,
+export const extractPathParametersFull: (path: Path) => Path = _.flow([
+  extractPathParametersSimple,
 ]);

--- a/src/ts/parsers/paths.ts
+++ b/src/ts/parsers/paths.ts
@@ -6,6 +6,7 @@ import {
   PathItemObject,
   ParameterObject,
 } from "openapi3-ts";
+import * as _ from "lodash";
 
 export interface Path {
   name: string;
@@ -26,8 +27,8 @@ export class Monad<A> {
   public map(f: (value: A) => A): Monad<A> {
     return Monad.of(f(this.value_));
   }
-  public chain(f: (monad: Monad<A>) => Monad<A>): Monad<A> {
-    return f(this);
+  public flatMap(f: (value: A) => Monad<A>): Monad<A> {
+    return f(this.value);
   }
   public get value(): A {
     return this.value_;
@@ -55,6 +56,16 @@ export class PathProcessor extends Monad<Path> {
   }
 }
 
+function compose<X>(...fs: Array<(x: X) => X>): (x: X) => X {
+  return (x: X) => fs.reduceRight((y, f) => f(y), x);
+}
+
 export const extractPathParameters = (path: Path): Path => {
   return PathProcessor.updatePathName(path, "/v1/pets");
 };
+
+export const extractPathParametersFull = compose(extractPathParameters);
+
+export const extractPathParametersFull2: (path: Path) => Path = _.flow([
+  extractPathParameters,
+]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10915,6 +10915,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript-optional@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/typescript-optional/-/typescript-optional-2.0.1.tgz#1dd4826bd751f78756e7eb3f96a16fbbeb3f7ee6"
+  integrity sha512-xuwmqsCjE4OeeMKxbNX3jjNcISGzYh5Q9R1rM5OyxEVNIr94CB5llCkfKW+1nZTKbbUV0axN3QAUuX2fus/DhQ==
+
 typescript@^3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.3.tgz#0eb320e4ace9b10eadf5bc6103286b0f8b7c224f"


### PR DESCRIPTION
If page contains text such as `GET /v1/pets/:id`, extract a path `/v1/pets/:id` with a `GET` operation having a path parameter with name `id`. Also has very preliminary support for `GET /v1/pets/(int :id)` to handle ReadTheDocs-like API documentation.