### PR TITLE
Refactor webpack source maps, do not minify in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Unmock chrome extension with webpack",
   "license": "MIT",
   "scripts": {
-    "build": "NODE_ENV=production webpack --config ./webpack/prod.config.js --display-error-details",
+    "build": "NODE_ENV=production DEBUG= webpack --config ./webpack/prod.config.js --display-error-details",
     "start": "NODE_ENV=development DEBUG=unmock* webpack-dev-server --config ./webpack/dev.config.js --display-error-details",
     "lint": "tslint --project .",
     "lint-fix": "tslint --project . --fix",

--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -2,9 +2,7 @@ const webpack = require("webpack"),
   path = require("path"),
   CleanWebpackPlugin = require("clean-webpack-plugin"),
   CopyWebpackPlugin = require("copy-webpack-plugin"),
-  HtmlWebpackPlugin = require("html-webpack-plugin"),
-  WriteFilePlugin = require("write-file-webpack-plugin"),
-  SourceMapDevToolPlugin = webpack.SourceMapDevToolPlugin;
+  HtmlWebpackPlugin = require("html-webpack-plugin");
 
 const alias = {};
 
@@ -131,8 +129,6 @@ const options = {
       filename: "swagger.html",
       chunks: ["swagger"],
     }),
-    new WriteFilePlugin(),
-    new SourceMapDevToolPlugin({}),
   ],
 };
 

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -24,12 +24,6 @@ for (let entryName in config.entry) {
   }
 }
 
-config.plugins = [
-  new WriteFilePlugin(),
-  new SourceMapDevToolPlugin(),
-  new webpack.HotModuleReplacementPlugin(),
-].concat(config.plugins || []);
-
 const devServer = {
   hot: true,
   contentBase: path.join(__dirname, "../build"),
@@ -39,6 +33,11 @@ const devServer = {
 
 const devOptions = {
   devServer,
+  plugins: [
+    new WriteFilePlugin(),
+    new SourceMapDevToolPlugin(),
+    new webpack.HotModuleReplacementPlugin(),
+  ],
 };
 
 module.exports = merge(config, devOptions);

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -1,7 +1,11 @@
 const merge = require("webpack-merge");
+const WriteFilePlugin = require("write-file-webpack-plugin");
+const webpack = require("webpack");
+const SourceMapDevToolPlugin = webpack.SourceMapDevToolPlugin;
+
 const path = require("path");
 const baseConfig = require("./base.config.js");
-const webpack = require("webpack");
+
 const _cloneDeep = require("lodash/cloneDeep");
 
 const config = _cloneDeep(baseConfig);
@@ -20,9 +24,11 @@ for (let entryName in config.entry) {
   }
 }
 
-config.plugins = [new webpack.HotModuleReplacementPlugin()].concat(
-  config.plugins || []
-);
+config.plugins = [
+  new WriteFilePlugin(),
+  new SourceMapDevToolPlugin(),
+  new webpack.HotModuleReplacementPlugin(),
+].concat(config.plugins || []);
 
 const devServer = {
   hot: true,

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -1,17 +1,13 @@
 const merge = require("webpack-merge");
 const baseConfig = require("./base.config.js");
-const _cloneDeep = require("lodash/cloneDeep");
 const webpack = require("webpack");
 const SourceMapDevToolPlugin = webpack.SourceMapDevToolPlugin;
 
-const config = _cloneDeep(baseConfig);
-
-config.plugins = [new SourceMapDevToolPlugin()].concat(config.plugins || []);
-
-module.exports = merge(config, {
+module.exports = merge(baseConfig, {
   devtool: false,
   optimization: {
     // Disable minification for now as Chrome does not accept minimized content script as UTF-8
     minimize: false,
   },
+  plugins: [new SourceMapDevToolPlugin()],
 });

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -1,4 +1,17 @@
 const merge = require("webpack-merge");
 const baseConfig = require("./base.config.js");
+const _cloneDeep = require("lodash/cloneDeep");
+const webpack = require("webpack");
+const SourceMapDevToolPlugin = webpack.SourceMapDevToolPlugin;
 
-module.exports = merge(baseConfig, {});
+const config = _cloneDeep(baseConfig);
+
+config.plugins = [new SourceMapDevToolPlugin()].concat(config.plugins || []);
+
+module.exports = merge(config, {
+  devtool: false,
+  optimization: {
+    // Disable minification for now as Chrome does not accept minimized content script as UTF-8
+    minimize: false,
+  },
+});


### PR DESCRIPTION
- Do not set source maps in webpack base so one can control the level of source maps individually
- Disable minification in production `yarn build` as loading the extension otherwise fails in Chrome with `Failed to load content script as it does not seem to be UTF-8 encoded`. There's something similar around in Google, might be fixable in future but I don't think minification is that critical for an extension anyway.
- Webpack bundles produced by the build are currently **huge**, they surely might need some splitting and minification sooner or later